### PR TITLE
fixed not working filters

### DIFF
--- a/src/MetaModels/Filter/Rules/FilterRuleTags.php
+++ b/src/MetaModels/Filter/Rules/FilterRuleTags.php
@@ -65,8 +65,7 @@ class FilterRuleTags extends FilterRule
     public function sanitizeValue()
     {
         $strTableNameId  = $this->objAttribute->get('tag_table');
-        // The tag_id field is empty if the source of the attribute is from type metamodel
-        $strColNameId    = $this->objAttribute->get('tag_id') ?:'id';
+        $strColNameId    = $this->objAttribute->get('tag_id') ?: 'id';
         $strColNameAlias = $this->objAttribute->get('tag_alias');
 
         $arrValues = is_array($this->value) ? $this->value : explode(',', $this->value);

--- a/src/MetaModels/Filter/Rules/FilterRuleTags.php
+++ b/src/MetaModels/Filter/Rules/FilterRuleTags.php
@@ -65,7 +65,8 @@ class FilterRuleTags extends FilterRule
     public function sanitizeValue()
     {
         $strTableNameId  = $this->objAttribute->get('tag_table');
-        $strColNameId    = $this->objAttribute->get('tag_id');
+        // The tag_id field is empty if the source of the attribute is from type metamodel
+        $strColNameId    = $this->objAttribute->get('tag_id') ?:'id';
         $strColNameAlias = $this->objAttribute->get('tag_alias');
 
         $arrValues = is_array($this->value) ? $this->value : explode(',', $this->value);


### PR DESCRIPTION
As mentioned in the comment:
If attribute is from type metamodel the tag_id field is empty instead preset to id