### PR TITLE
Update AbstractTags.php

### DIFF
--- a/src/MetaModels/Attribute/Tags/AbstractTags.php
+++ b/src/MetaModels/Attribute/Tags/AbstractTags.php
@@ -382,6 +382,9 @@ abstract class AbstractTags extends BaseComplex
         $valuesToUpdate = array_diff($tagIds, $valuesToAdd);
         if ($valuesToUpdate) {
             foreach ($valuesToUpdate as $valueId) {
+	            if (!isset($tags[$valueId])) {
+	            	continue;
+	            }
                 if (!array_key_exists('tag_value_sorting', $tags[$valueId])) {
                     continue;
                 }


### PR DESCRIPTION
catch an error if array key isn't set. the error show up when I save a model.
